### PR TITLE
Provide network admins with clearer support options

### DIFF
--- a/app/views/help/new.html.erb
+++ b/app/views/help/new.html.erb
@@ -1,16 +1,16 @@
-<div><% content_for :page_title, 'Contact Us - GovWifi' %></div>
-<div><% content_for :meta_description, 'Contact us for help and support installing GovWifi in your organisation.' %></div>
+<div><% content_for :page_title, 'Network administrator support - GovWifi' %></div>
+<div><% content_for :meta_description, 'Help and support for network administrators installing or managing GovWifi in public sector organisations.' %></div>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l">Contact GovWifi</h2>
+    <h2 class="govuk-heading-l">Network administrator support</h2>
     <div class="govuk-details">
     <p>
-      We provide network administrator guidance on how to offer and manage GovWifi in your organisation in our
+      We provide network administrator guidance on how to set up and manage GovWifi in your organisation in our
       <%= link_to 'technical documentation', SITE_CONFIG['organisation_docs_link'], class: "govuk-link" %>.
     </p>
     <p>
-      If you are having trouble connecting to GovWifi, see our <%= link_to 'user support guidance', 'https://www.wifi.service.gov.uk/support/', class: "govuk-link" %> on common issues.
+      If users in your organisation are having trouble connecting devices to GovWifi, please refer them to our <%= link_to 'user support guidance', 'https://www.wifi.service.gov.uk/support/', class: "govuk-link" %> on common issues.
     </p>
 
       <h2 class="govuk-body-m">How can we help?</h2>
@@ -19,15 +19,15 @@
         <div class="govuk-radio">
           <div class="govuk-radios__item">
             <%= radio_button_tag(:choice, :technical_support, nil, class: "govuk-radios__input") %>
-            <%= label_tag(:choice_technical_support, "Network administrator technical support", class: 'govuk-label govuk-radios__label') %>
+            <%= label_tag(:choice_technical_support, "Setting up GovWifi in your organisation support", class: 'govuk-label govuk-radios__label') %>
           </div>
           <div class="govuk-radios__item">
             <%= radio_button_tag(:choice, :admin_account, nil, class: "govuk-radios__input") %>
-            <%= label_tag(:choice_admin_account, "Network administrator account support", class: 'govuk-label govuk-radios__label') %>
+            <%= label_tag(:choice_admin_account, "Managing GovWifi in your organisation support", class: 'govuk-label govuk-radios__label') %>
           </div>
           <div class="govuk-radios__item">
             <%= radio_button_tag(:choice, :user_support, nil, class: "govuk-radios__input") %>
-            <%= label_tag(:choice_user_support, "Connecting to GovWifi user support", class: 'govuk-label govuk-radios__label govuk-!-margin-bottom-4') %>
+            <%= label_tag(:choice_user_support, "Request GovWifi user information ", class: 'govuk-label govuk-radios__label govuk-!-margin-bottom-4') %>
           </div>
         </div>
         <%= submit_tag('Continue', class: 'govuk-button') %>


### PR DESCRIPTION
We need to provide network admins with clearer options regarding the support we provide:
-set up GovWifi support
- manage Govwifi support
- user information support